### PR TITLE
Add quick-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All scripts listed below. As you can see they are highly personalized to my work
 - [quick-bin](#bin)
 - [quick-html](#html)
 - [quick-budo](#budo)
+- [quick-component](#component)
 
 ### test
 
@@ -133,6 +134,25 @@ The above command installs budo, garnish, babelify, errorify and adds the follow
 ```
 "start": "budo test.js -t babelify -p errorify | garnish"
 ```
+
+### component
+
+Create a folder with a script, css and template file.
+
+```sh
+quick-component ./src/components/my-comp
+```
+
+Options:
+
+```
+quick-component [path] [opts]
+  [path]      the folder that will be created
+  --css, -c   the name for the style file (default style.css)
+  --script, -s   the name for the script file (default index.js)
+  --template, -t   the name for the template file (default template.html)
+```
+
 ## License
 
 MIT, see [LICENSE.md](http://github.com/mattdesl/quick-stub/blob/master/LICENSE.md) for details.

--- a/bin/component.js
+++ b/bin/component.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+var argv = require('minimist')(process.argv.slice(2))
+var cwd = process.cwd()
+var mkdirp = require('mkdirp')
+var path = require('path')
+var fs = require('fs')
+
+var style = argv.c || argv.css || 'style.css'
+var script = argv.s || argv.script || 'index.js'
+var tpl = argv.t || argv.template || 'template.html'
+var output = path.join(cwd, argv._[0])
+
+mkdirp(output, function(err) {
+    if (err) throw err
+
+    var all = [style, script, tpl];
+    all.forEach(function(file) {
+        fs.writeFile(path.join(output, file), '', function(err) {
+            if (err) throw err
+        });
+    })
+})

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/mattdesl"
   },
   "bin": {
+    "quick-component": "./bin/component.js",
     "quick-build": "./bin/build.js",
     "quick-budo": "./bin/budo.js",
     "quick-test": "./bin/test.js",


### PR DESCRIPTION
My component use-case makes me regularly create an empty folder with corresponding script/style/template files. So I added this one.
It doesn't use quick-stub templates, only creates empty files because this is more or less lib/framework-dependent + conventions and stuff. File names default to `index.js`, `style.css` and `template.html` but parameters allow to change that.
